### PR TITLE
tdsl_driver/network_io_base: adjustable connection attempt timeout pa…

### DIFF
--- a/examples/arduino/01-initialize-library/01-initialize-library.ino
+++ b/examples/arduino/01-initialize-library/01-initialize-library.ino
@@ -165,25 +165,29 @@ void setup() {
     // save some precious SRAM space.
     decltype(driver)::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.22"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.22"); // WL
     // SQL server port number
-    params.port        = 14333; // default port is 1433
+    params.port                = 14333; // default port is 1433
     // SQL server login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // SQL server login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // Client name(optional)
-    params.client_name = TDSL_PMEMSTR("arduino uno");
+    params.client_name         = TDSL_PMEMSTR("arduino uno");
     // App name(optional)
-    params.app_name    = TDSL_PMEMSTR("initialize library example");
+    params.app_name            = TDSL_PMEMSTR("initialize library example");
     // Database name(optional)
-    params.db_name     = TDSL_PMEMSTR("master");
+    params.db_name             = TDSL_PMEMSTR("master");
     // TDS packet size
     // Recommendation: Half of the network buffer.
     // This is the PDU size that TDS protocol will use.
     // Given that the example has 768 bytes of network buffer space,
     // we set this to 512 to allow some headroom for fragmentation.
-    params.packet_size = {512};
+    params.packet_size         = {512};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
 
     SERIAL_PRINTLNF("Initializing tdslite");
 

--- a/examples/arduino/02-create-insert-select-delete/02-create-insert-select-delete.ino
+++ b/examples/arduino/02-create-insert-select-delete/02-create-insert-select-delete.ino
@@ -166,25 +166,29 @@ void setup() {
     // save some precious SRAM space.
     decltype(driver)::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.22"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.22"); // WL
     // SQL server port number
-    params.port        = 14333; // default port is 1433
+    params.port                = 14333; // default port is 1433
     // SQL server login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // SQL server login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // Client name(optional)
-    params.client_name = TDSL_PMEMSTR("arduino mega");
+    params.client_name         = TDSL_PMEMSTR("arduino mega");
     // App name(optional)
-    params.app_name    = TDSL_PMEMSTR("sketch");
+    params.app_name            = TDSL_PMEMSTR("sketch");
     // Database name(optional)
-    params.db_name     = TDSL_PMEMSTR("master");
+    params.db_name             = TDSL_PMEMSTR("master");
     // TDS packet size
     // Recommendation: Half of the network buffer.
     // This is the PDU size that TDS protocol will use.
     // Given that the example has 768 bytes of network buffer space,
     // we set this to 512 to allow some headroom for fragmentation.
-    params.packet_size = {512};
+    params.packet_size         = {512};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
 
     SERIAL_PRINTLNF("Initializing tdslite");
 

--- a/examples/arduino/03-select-rows/03-select-rows.ino
+++ b/examples/arduino/03-select-rows/03-select-rows.ino
@@ -167,25 +167,29 @@ void setup() {
     // save some precious SRAM space.
     decltype(driver)::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.22"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.22"); // WL
     // SQL server port number
-    params.port        = 14333; // default port is 1433
+    params.port                = 14333; // default port is 1433
     // SQL server login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // SQL server login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // Client name(optional)
-    params.client_name = TDSL_PMEMSTR("arduino mega");
+    params.client_name         = TDSL_PMEMSTR("arduino mega");
     // App name(optional)
-    params.app_name    = TDSL_PMEMSTR("sketch");
+    params.app_name            = TDSL_PMEMSTR("sketch");
     // Database name(optional)
-    params.db_name     = TDSL_PMEMSTR("master");
+    params.db_name             = TDSL_PMEMSTR("master");
     // TDS packet size
     // Recommendation: Half of the network buffer.
     // This is the PDU size that TDS protocol will use.
     // Given that the example has 768 bytes of network buffer space,
     // we set this to 512 to allow some headroom for fragmentation.
-    params.packet_size = {512};
+    params.packet_size         = {512};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
 
     SERIAL_PRINTLNF("Initializing tdslite");
 

--- a/examples/arduino/04-info-callback/04-info-callback.ino
+++ b/examples/arduino/04-info-callback/04-info-callback.ino
@@ -113,12 +113,14 @@ static void info_callback(void *, const tdsl::tds_info_token & token) noexcept {
  */
 static inline void tdslite_setup() {
     decltype(driver)::progmem_connection_parameters params;
-    params.server_name = TDSL_PMEMSTR("192.168.1.45"); // WL
-    params.port        = 14333;                        // default port is 1433
-    params.user_name   = TDSL_PMEMSTR("sa");
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
-    params.db_name     = TDSL_PMEMSTR("master");
-    params.packet_size = {512};
+    params.server_name         = TDSL_PMEMSTR("192.168.1.45"); // WL
+    params.port                = 14333;                        // default port is 1433
+    params.user_name           = TDSL_PMEMSTR("sa");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.db_name             = TDSL_PMEMSTR("master");
+    params.packet_size         = {512};
+    params.conn_retry_count    = 5;
+    params.conn_retry_delay_ms = 2000;
 
     // Set a callback function that'll process the
     // info/error messages sent by the server

--- a/examples/arduino/05-query-with-parameters/05-query-with-parameters.ino
+++ b/examples/arduino/05-query-with-parameters/05-query-with-parameters.ino
@@ -166,25 +166,29 @@ void setup() {
     // save some precious SRAM space.
     decltype(driver)::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.45"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.45"); // WL
     // SQL server port number
-    params.port        = 14333; // default port is 1433
+    params.port                = 14333; // default port is 1433
     // SQL server login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // SQL server login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // Client name(optional)
-    params.client_name = TDSL_PMEMSTR("arduino mega");
+    params.client_name         = TDSL_PMEMSTR("arduino mega");
     // App name(optional)
-    params.app_name    = TDSL_PMEMSTR("sketch");
+    params.app_name            = TDSL_PMEMSTR("sketch");
     // Database name(optional)
-    params.db_name     = TDSL_PMEMSTR("master");
+    params.db_name             = TDSL_PMEMSTR("master");
     // TDS packet size
     // Recommendation: Half of the network buffer.
     // This is the PDU size that TDS protocol will use.
     // Given that the example has 768 bytes of network buffer space,
     // we set this to 512 to allow some headroom for fragmentation.
-    params.packet_size = {512};
+    params.packet_size         = {512};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
 
     SERIAL_PRINTLNF("Initializing tdslite");
 

--- a/examples/arduino/06-custom-malloc/06-custom-malloc.ino
+++ b/examples/arduino/06-custom-malloc/06-custom-malloc.ino
@@ -139,15 +139,19 @@ void setup() {
 
     decltype(driver)::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.45"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.45"); // WL
     // SQL server port number
-    params.port        = 14333; // default port is 1433
+    params.port                = 14333; // default port is 1433
     // SQL server login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // SQL server login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // TDS packet size
-    params.packet_size = {512};
+    params.packet_size         = {512};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
 
     SERIAL_PRINTLNF("Initializing tdslite");
 

--- a/examples/boards/uno_wifi_r2/uno_wifi_r2.ino
+++ b/examples/boards/uno_wifi_r2/uno_wifi_r2.ino
@@ -192,22 +192,26 @@ bool tdslite_setup() noexcept {
     SERIAL_PRINTLNF("... init tdslite ...");
     decltype(driver)::connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = SKETCH_DB_IP_OR_HOSTNAME; // WL
+    params.server_name         = SKETCH_DB_IP_OR_HOSTNAME; // WL
     //  SQL server port number
-    params.port        = SKETCH_DB_PORT;
+    params.port                = SKETCH_DB_PORT;
     // Login user
-    params.user_name   = SKETCH_DB_USERNAME;
+    params.user_name           = SKETCH_DB_USERNAME;
     // Login user password
-    params.password    = SKETCH_DB_PASSWORD;
+    params.password            = SKETCH_DB_PASSWORD;
     // Client name(optional)
-    params.client_name = "arduino uno test sketch";
+    params.client_name         = "arduino uno test sketch";
     // App name(optional)
-    params.app_name    = "sketch";
+    params.app_name            = "sketch";
     // Database name(optional)
-    params.db_name     = SKETCH_DB_NAME;
+    params.db_name             = SKETCH_DB_NAME;
     // TDS packet size
     // Recommendation: Half of the network buffer.
-    params.packet_size = {SKETCH_TDSL_PACKET_SIZE};
+    params.packet_size         = {SKETCH_TDSL_PACKET_SIZE};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
     driver.set_info_callback(&info_callback, nullptr);
     auto cr = driver.connect(params);
     if (not(decltype(driver)::e_driver_error_code::success == cr)) {

--- a/examples/minimal-sql-shell/minimal.cpp
+++ b/examples/minimal-sql-shell/minimal.cpp
@@ -184,12 +184,14 @@ int main(void) {
 
     // Define the connection parameters
     decltype(driver)::connection_parameters conn_params;
-    conn_params.server_name = "mssql-2017";
-    conn_params.port        = 1433;
-    conn_params.user_name   = "sa";
-    conn_params.password    = "2022-tds-lite-test!";
-    conn_params.app_name    = "tdslite minimal example";
-    conn_params.db_name     = "master";
+    conn_params.server_name         = "mssql-2017";
+    conn_params.port                = 1433;
+    conn_params.user_name           = "sa";
+    conn_params.password            = "2022-tds-lite-test!";
+    conn_params.app_name            = "tdslite minimal example";
+    conn_params.db_name             = "master";
+    conn_params.conn_retry_count    = 5;
+    conn_params.conn_retry_delay_ms = 2000;
     // Connect & login to the SQL server described in conn_params
     driver.connect(conn_params);
 

--- a/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
+++ b/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
@@ -94,7 +94,7 @@ namespace tdsl { namespace net {
             do_disconnect();
 
             int cr      = 0;
-            int retries = 10;
+            int retries = this->conn_retry_count;
 
             // There may be residue data in network buffer
             // Reset it to ensure a clean start
@@ -135,7 +135,7 @@ namespace tdsl { namespace net {
                 }
 
                 TDSL_DEBUG_PRINTLN("... connection attempt failed (%d) ...", cr);
-                delay(3000);
+                delay(this->conn_retry_delay_ms);
             }
 
             // Reset the network buffer so it's ready to

--- a/src/tdslite/detail/tdsl_driver.hpp
+++ b/src/tdslite/detail/tdsl_driver.hpp
@@ -55,7 +55,12 @@ namespace tdsl { namespace detail {
 
         template <typename T>
         struct connection_parameters_base : public T {
+            // SQL server port
             tdsl::uint16_t port = {1433};
+            // How many attempts the driver should make to establish a connection
+            tdsl::uint32_t conn_retry_count{10};
+            // The delay between each connection attempt (milliseconds)
+            tdsl::uint32_t conn_retry_delay_ms{3000};
 
             /**
              * Check whether connection parameters have
@@ -125,6 +130,8 @@ namespace tdsl { namespace detail {
             if (not(e_driver_error_code::success == pvr)) {
                 return pvr;
             }
+
+            tds_ctx.set_connection_timeout_params(p.conn_retry_count, p.conn_retry_delay_ms);
 
             if (not tds_ctx.connect(p.server_name, p.port)) {
                 return e_driver_error_code::connection_failed;

--- a/src/tdslite/util/tdsl_expected.hpp
+++ b/src/tdslite/util/tdsl_expected.hpp
@@ -150,7 +150,7 @@ namespace tdsl {
             return has_expected;
         }
 
-        inline operator bool() const noexcept {
+        inline explicit operator bool() const noexcept {
             return has_value();
         }
 

--- a/tests/integration/it_tdsl_command_context.cpp
+++ b/tests/integration/it_tdsl_command_context.cpp
@@ -82,7 +82,7 @@ struct tds_command_ctx_it_fixture : public ::testing::Test {
     virtual void SetUp() override {
         login_ctx_t login{tds_ctx};
         const auto & params = mssql_2017_creds();
-        ASSERT_EQ(tds_ctx.do_connect(params.server_name, /*port=*/1433), true);
+        ASSERT_TRUE(tds_ctx.do_connect(params.server_name, /*port=*/1433));
         ASSERT_EQ(login.do_login(params), login_ctx_t::e_login_status::success);
         ASSERT_TRUE(tds_ctx.is_authenticated());
     }

--- a/tests/integration/it_tdsl_login_context.cpp
+++ b/tests/integration/it_tdsl_login_context.cpp
@@ -33,7 +33,7 @@ using tds_ctx_t = uut_t::tds_context_type;
 struct tds_login_ctx_it_fixture : public ::testing::Test {
 
     virtual void SetUp() override {
-        ASSERT_EQ(true, tds_ctx.do_connect("mssql-2017", /*port=*/1433));
+        ASSERT_TRUE(tds_ctx.do_connect("mssql-2017", /*port=*/1433));
     }
 
     virtual void TearDown() override {}

--- a/tests/sketches/arduino/arduino.cpp
+++ b/tests/sketches/arduino/arduino.cpp
@@ -141,23 +141,27 @@ void initTdsliteDriver() {
     tdsl::tdslite_malloc_free(my_malloc, my_free);
     tdsl::arduino_driver<EthernetClient>::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.27"); // WL
+    params.server_name         = TDSL_PMEMSTR("192.168.1.27"); // WL
     // params.server_name = TDSL_PMEMSTR("192.168.1.45"); // WS
     //  SQL server port number
-    params.port        = 14333;
+    params.port                = 14333;
     // Login user
-    params.user_name   = TDSL_PMEMSTR("sa");
+    params.user_name           = TDSL_PMEMSTR("sa");
     // Login user password
-    params.password    = TDSL_PMEMSTR("2022-tds-lite-test!");
+    params.password            = TDSL_PMEMSTR("2022-tds-lite-test!");
     // Client name(optional)
-    params.client_name = TDSL_PMEMSTR("arduino mega");
+    params.client_name         = TDSL_PMEMSTR("arduino mega");
     // App name(optional)
-    params.app_name    = TDSL_PMEMSTR("sketch");
+    params.app_name            = TDSL_PMEMSTR("sketch");
     // Database name(optional)
-    params.db_name     = TDSL_PMEMSTR("master");
+    params.db_name             = TDSL_PMEMSTR("master");
     // TDS packet size
     // Recommendation: Half of the network buffer.
-    params.packet_size = {SKETCH_TDSL_PACKET_SIZE};
+    params.packet_size         = {SKETCH_TDSL_PACKET_SIZE};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 8;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2500;
     driver.set_info_callback(&info_callback, nullptr);
     auto result = driver.connect(params);
     (void) result;

--- a/tests/sketches/esp/esp.cpp
+++ b/tests/sketches/esp/esp.cpp
@@ -138,23 +138,27 @@ bool tdslite_setup() noexcept {
     SERIAL_PRINTLNF("... init tdslite ...");
     decltype(driver)::connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = "192.168.1.27"; // WL
+    params.server_name         = "192.168.1.27"; // WL
     // params.server_name = PSTR("192.168.1.45"); // WS
     //  SQL server port number
-    params.port        = 14333;
+    params.port                = 14333;
     // Login user
-    params.user_name   = "sa";
+    params.user_name           = "sa";
     // Login user password
-    params.password    = "2022-tds-lite-test!";
+    params.password            = "2022-tds-lite-test!";
     // Client name(optional)
-    params.client_name = "arduino mega";
+    params.client_name         = "arduino mega";
     // App name(optional)
-    params.app_name    = "sketch";
+    params.app_name            = "sketch";
     // Database name(optional)
-    params.db_name     = "master";
+    params.db_name             = "master";
     // TDS packet size
     // Recommendation: Half of the network buffer.
-    params.packet_size = {SKETCH_TDSL_PACKET_SIZE};
+    params.packet_size         = {SKETCH_TDSL_PACKET_SIZE};
+    // How many times the driver should attempt to connect to the server
+    params.conn_retry_count    = 5;
+    // Delay between each connection attempt (milliseconds)
+    params.conn_retry_delay_ms = 2000;
     driver.set_info_callback(&info_callback, nullptr);
     auto cr = driver.connect(params);
     if (not(decltype(driver)::e_driver_error_code::success == cr)) {


### PR DESCRIPTION
…rameters

the connection attempt count and attempt delay (conn_retry_count, conn_retry_delay_ms) are now configurable, allowing end user to tweak them as needed.

updated all examples to reflect the changes.

network_io_base: the code now does not assume that do_recv() would succeed, and now handles the error case properly.

Fixes #45