### PR TITLE
sql_decimal/sql_numeric: initial support for reading numeric/decimal …

### DIFF
--- a/src/tdslite/detail/sqltypes/sql_basics.hpp
+++ b/src/tdslite/detail/sqltypes/sql_basics.hpp
@@ -1,0 +1,28 @@
+/**
+ * ____________________________________________________
+ * Basic SQL data types
+ *
+ * @file   sql_basics.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   05.10.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQL_BASICS_HPP
+#define TDSL_DETAIL_SQLTYPES_SQL_BASICS_HPP
+
+#include <tdslite/util/tdsl_inttypes.hpp>
+
+namespace tdsl {
+    using sql_bit      = bool;
+    using sql_tinyint  = tdsl::uint8_t;
+    using sql_smallint = tdsl::int16_t;
+    using sql_int      = tdsl::int32_t;
+    using sql_bigint   = tdsl::int64_t;
+    using sql_float4   = float;
+    using sql_float8   = double;
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/sqltypes/sql_datetime.hpp
+++ b/src/tdslite/detail/sqltypes/sql_datetime.hpp
@@ -1,0 +1,73 @@
+/**
+ * ____________________________________________________
+ * sql_datetime data type
+ *
+ * @file   sql_datetime.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   05.10.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQLDATETIME_HPP
+#define TDSL_DETAIL_SQLTYPES_SQLDATETIME_HPP
+
+#include <tdslite/util/tdsl_binary_reader.hpp>
+#include <tdslite/util/tdsl_span.hpp>
+#include <tdslite/detail/sqltypes/sql_type_base.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
+
+namespace tdsl {
+
+    /**
+     * datetime sql type
+     */
+    struct sql_datetime : public sql_type_base {
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Construct a new SQL smalldatetime object
+         *
+         * @param [in] v View to bytes to be interpreted as sql_smalldatetime
+         */
+        inline explicit sql_datetime(tdsl::byte_view v,
+                                     const tdsl::tds_column_info & col) noexcept {
+            (void) col;
+            TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::int32_t) + sizeof(uint32_t)));
+            tdsl::binary_reader<tdsl::endian::little> br{v};
+            days_elapsed         = br.read<tdsl::int32_t>();
+            centiseconds_elapsed = br.read<tdsl::uint32_t>();
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Convert datetime to unix timestamp
+         *
+         * @return tdsl::uint64_t datetime value as unix timestamp
+         */
+        inline tdsl::uint64_t to_unix_timestamp() const noexcept {
+            constexpr auto days_between_epochs = ((1970 - 1900) * 365);
+            if (days_elapsed < days_between_epochs) {
+                return 0; // 1-1-1970
+            }
+            return ((days_elapsed - days_between_epochs) * 86400ul) + (centiseconds_elapsed / 100);
+        }
+
+        // --------------------------------------------------------------------------------
+
+        // One 4-byte signed integer that represents the number of days
+        // since January 1, 1900. Negative numbers are allowed to represent
+        // dates since January 1, 1753.
+        tdsl::int32_t days_elapsed;
+        // One 4-byte unsigned integer that represents the number of one
+        // three-hundredths of a second (300 counts per second) elapsed
+        // since 12 AM that day.
+        tdsl::uint32_t centiseconds_elapsed;
+    };
+
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/sqltypes/sql_decimal.hpp
+++ b/src/tdslite/detail/sqltypes/sql_decimal.hpp
@@ -1,0 +1,141 @@
+/**
+ * ____________________________________________________
+ * sql_decimal(/sql_numeric) data type
+ *
+ * @file   sql_decimal.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   05.10.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQL_DECIMAL_HPP
+#define TDSL_DETAIL_SQLTYPES_SQL_DECIMAL_HPP
+
+#include <tdslite/util/tdsl_binary_reader.hpp>
+#include <tdslite/util/tdsl_span.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
+#include <tdslite/detail/sqltypes/sql_type_base.hpp>
+
+namespace tdsl {
+
+    /**
+     * decimal sql type
+     */
+    struct sql_decimal : public sql_type_base {
+
+        /**
+         * Construct a new sql money object
+         *
+         * @param [in] v View to bytes to be interpreted as sql_decimal
+         */
+        inline explicit sql_decimal(tdsl::byte_view v, const tdsl::tds_column_info & col) noexcept {
+
+            TDSL_ASSERT(stor.value == 0);
+            TDSL_ASSERT(flags.precision == 0);
+            TDSL_ASSERT(flags.scale == 0);
+            TDSL_ASSERT(flags.sign == 0);
+
+            // Decimal or Numeric is defined as decimal(p, s) or numeric(p, s), where p is the
+            // precision and s is the scale. The value is represented in the following sequence:
+            //  * One 1-byte unsigned integer that represents the sign of the decimal value as
+            //  follows:
+            //      * 0 means negative.
+            //      * 1 means nonnegative.
+            //  * One 4-, 8-, 12-, or 16-byte signed integer that represents the decimal value
+            //  multiplied by 10^s.
+            // The maximum size of this integer is determined based on p as follows:
+            //  * 4 bytes if 1 <= p <= 9.
+            //  * 8 bytes if 10 <= p <= 19.
+            //  * 12 bytes if 20 <= p <= 28.
+            //  * 16 bytes if 29 <= p <= 38.
+            // The actual size of this integer could be less than the maximum size, depending on
+            // the value. In all cases, the integer part MUST be 4, 8, 12, or 16 bytes.
+            // https://github.com/microsoft/referencesource/blob/master/System.Data/System/Data/SQLTypes/SQLDecimal.cs
+            tdsl::binary_reader<tdsl::endian::little> br{v};
+
+            flags.sign                = br.read<bool>();
+
+            // https://www.h-schmidt.net/FloatConverter/IEEE754.html
+            tdsl::uint8_t read_length = 0;
+            if (col.typeprops.ps.precision >= 1 && col.typeprops.ps.precision <= 9) {
+                TDSL_ASSERT(v.size_bytes() == 5);
+                read_length = 4;
+            }
+            else if (col.typeprops.ps.precision <= 18) {
+                TDSL_ASSERT(v.size_bytes() == 9);
+                read_length = 8;
+            }
+            // Precision values larger than 18 is not supported.
+            else if (col.typeprops.ps.precision <= 28) {
+                TDSL_NOT_YET_IMPLEMENTED;
+                TDSL_ASSERT(v.size_bytes() == 13);
+                read_length = 12;
+            }
+            else if (col.typeprops.ps.precision <= 38) {
+                // These are not supported
+                TDSL_NOT_YET_IMPLEMENTED;
+                TDSL_ASSERT(v.size_bytes() == 17);
+                read_length = 16;
+            }
+            else {
+                TDSL_ASSERT_MSG(false, "Invalid precision value for decimal/numeric!");
+            }
+
+            TDSL_ASSERT(read_length <= sizeof(stor.raw));
+
+            flags.precision            = col.typeprops.ps.precision;
+            flags.scale                = col.typeprops.ps.scale;
+
+            const tdsl::byte_view data = br.read(read_length);
+            memcpy(stor.raw, data.data(), data.size_bytes());
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Integer part of the decimal
+         */
+        inline TDSL_NODISCARD tdsl::int64_t integer() const noexcept {
+            const auto mod = modifier();
+            return (stor.value / mod) * (flags.sign ? 1 : -1);
+        }
+
+        /**
+         * Fraction part of the decimal
+         */
+        inline TDSL_NODISCARD tdsl::int64_t fraction() const noexcept {
+            const auto mod = modifier();
+            return (stor.value % mod) * (flags.sign ? 1 : -1);
+        }
+
+    private:
+        inline TDSL_NODISCARD tdsl::int64_t modifier() const noexcept {
+            tdsl::int64_t result = 1;
+            for (tdsl::uint64_t i = 0; i < flags.scale; i++) {
+                result *= 10;
+            }
+            return result;
+        }
+
+        struct flags {
+            tdsl::uint8_t precision : 6; // 0/31
+            bool sign : 1;               // 0 - negative, 1 - positive
+            bool reserved_1 : 1;
+            tdsl::uint8_t scale : 6;
+            bool reserved_2 : 2;
+            tdsl::uint64_t reserved_3 : 48;
+        } flags = {};
+
+        union storage {
+            tdsl::int64_t value;
+            tdsl::uint8_t raw [sizeof(decltype(value))];
+        } stor = {};
+    };
+
+    using sql_numeric = sql_decimal;
+
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/sqltypes/sql_money.hpp
+++ b/src/tdslite/detail/sqltypes/sql_money.hpp
@@ -1,0 +1,84 @@
+/**
+ * ____________________________________________________
+ * sql_money data type
+ *
+ * @file   sql_money.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   05.10.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQLMONEY_HPP
+#define TDSL_DETAIL_SQLTYPES_SQLMONEY_HPP
+
+#include <tdslite/util/tdsl_binary_reader.hpp>
+#include <tdslite/util/tdsl_span.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
+#include <tdslite/detail/sqltypes/sql_type_base.hpp>
+
+namespace tdsl {
+
+    /**
+     * money sql type
+     */
+    struct sql_money : public sql_type_base {
+
+        /**
+         * Construct a new sql money object
+         *
+         * @param [in] v View to bytes to be interpreted as sql_money
+         */
+        inline explicit sql_money(tdsl::byte_view v, const tdsl::tds_column_info & col) noexcept {
+            (void) col;
+            TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::uint32_t) * 2));
+            // money is represented as an 8-byte signed integer. The TDS value is the money
+            // value multiplied by 10^4. The 8-byte signed integer itself is represented in the
+            // following sequence:
+            // * One 4-byte integer that represents the more significant half.
+            // * One 4-byte integer that represents the less significant half.
+            tdsl::binary_reader<tdsl::endian::little> br{v};
+            const tdsl::uint32_t msh = br.read<tdsl::uint32_t>();
+            const tdsl::uint32_t lsh = br.read<tdsl::uint32_t>();
+            value = static_cast<tdsl::int64_t>((static_cast<tdsl::uint64_t>(msh) << 32) |
+                                               (static_cast<tdsl::uint64_t>(lsh)));
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Calculate the integer part
+         *
+         * @return tdsl::int64_t sql_money integer part
+         */
+        inline TDSL_NODISCARD tdsl::int64_t integer() const noexcept {
+            return value / 10000;
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Calculate the fraction part
+         *
+         * @return tdsl::int64_t sql_money fraction part
+         */
+        inline TDSL_NODISCARD tdsl::int64_t fraction() const noexcept {
+            return value % 10000;
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Raw 8 byte integer stored in the database
+         */
+        inline TDSL_NODISCARD tdsl::int64_t raw() const noexcept {
+            return value;
+        }
+
+    private:
+        tdsl::int64_t value;
+    };
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/sqltypes/sql_smalldatetime.hpp
+++ b/src/tdslite/detail/sqltypes/sql_smalldatetime.hpp
@@ -1,0 +1,71 @@
+/**
+ * ____________________________________________________
+ * sql_smalldatetime data type
+ *
+ * @file   sql_smalldatetime.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   05.10.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQLSMALLDATETIME_HPP
+#define TDSL_DETAIL_SQLTYPES_SQLSMALLDATETIME_HPP
+
+#include <tdslite/util/tdsl_binary_reader.hpp>
+#include <tdslite/util/tdsl_span.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
+#include <tdslite/detail/sqltypes/sql_type_base.hpp>
+
+namespace tdsl {
+
+    /**
+     * smalldatetime sql type
+     */
+    struct sql_smalldatetime : public sql_type_base {
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Construct a new SQL smalldatetime object
+         *
+         * @param [in] v View to bytes to be interpreted as sql_smalldatetime
+         */
+        inline explicit sql_smalldatetime(tdsl::byte_view v,
+                                          const tdsl::tds_column_info & col) noexcept {
+            (void) col;
+            TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::uint16_t) * 2));
+            tdsl::binary_reader<tdsl::endian::little> br{v};
+            days_elapsed    = br.read<tdsl::uint16_t>();
+            minutes_elapsed = br.read<tdsl::uint16_t>();
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
+         * Convert smalldatetime to unix timestamp
+         *
+         * @return tdsl::uint64_t smalldatetime value as unix timestamp
+         */
+        inline tdsl::uint64_t to_unix_timestamp() const noexcept {
+            constexpr auto days_between_epochs = ((1970 - 1900) * 365);
+            if (days_elapsed < days_between_epochs) {
+                return 0; // 1-1-1970
+            }
+            return ((days_elapsed - days_between_epochs) * 86400) + (minutes_elapsed * 60);
+        }
+
+        // --------------------------------------------------------------------------------
+
+        // One 2-byte unsigned integer that represents the
+        // number of days since January 1, 1900.
+        tdsl::uint16_t days_elapsed;
+        // One 2-byte unsigned integer that represents the
+        // number of minutes elapsed since 12 AM that day.
+        tdsl::uint16_t minutes_elapsed;
+    };
+
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/sqltypes/sql_type_base.hpp
+++ b/src/tdslite/detail/sqltypes/sql_type_base.hpp
@@ -1,0 +1,20 @@
+/**
+ * ____________________________________________________
+ * Base type for all sql data type objects
+ *
+ * @file   sql_type_base.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   27.02.2024
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_SQLTYPES_SQL_TYPE_BASE_HPP
+#define TDSL_DETAIL_SQLTYPES_SQL_TYPE_BASE_HPP
+
+namespace tdsl {
+    struct sql_type_base {};
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/tdsl_allocator.hpp
+++ b/src/tdslite/detail/tdsl_allocator.hpp
@@ -145,12 +145,11 @@ namespace tdsl {
 
         template <typename... Args>
         static TDSL_NODISCARD auto create_n(tdsl::uint32_t n_elems, Args &&... args) -> T * {
-            void * mem = tdslite_malloc(sizeof(T) * n_elems);
-            if (nullptr == mem) {
+
+            T * storage = allocate(n_elems);
+            if (nullptr == storage) {
                 return nullptr;
             }
-
-            T * storage = static_cast<T *>(mem);
 
             // Invoke placement new for each element
             construct(storage, n_elems, TDSL_FORWARD(args)...);

--- a/src/tdslite/detail/tdsl_field.hpp
+++ b/src/tdslite/detail/tdsl_field.hpp
@@ -13,196 +13,21 @@
 #ifndef TDSL_DETAIL_TDSL_FIELD_HPP
 #define TDSL_DETAIL_TDSL_FIELD_HPP
 
+#include <tdslite/util/tdsl_expected.hpp>
 #include <tdslite/util/tdsl_span.hpp>
 #include <tdslite/util/tdsl_inttypes.hpp>
 #include <tdslite/util/tdsl_binary_reader.hpp>
 #include <tdslite/util/tdsl_type_traits.hpp>
 #include <tdslite/util/tdsl_macrodef.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
+#include <tdslite/detail/sqltypes/sql_type_base.hpp>
+#include <tdslite/detail/sqltypes/sql_basics.hpp>
+#include <tdslite/detail/sqltypes/sql_datetime.hpp>
+#include <tdslite/detail/sqltypes/sql_smalldatetime.hpp>
+#include <tdslite/detail/sqltypes/sql_money.hpp>
+#include <tdslite/detail/sqltypes/sql_decimal.hpp>
 
 namespace tdsl {
-
-    namespace sqltypes {
-        using s_bit      = bool;
-        using s_tinyint  = tdsl::uint8_t;
-        using s_smallint = tdsl::int16_t;
-        using s_int      = tdsl::int32_t;
-        using s_bigint   = tdsl::int64_t;
-        using s_float4   = float;
-        using s_float8   = double;
-
-        struct sql_data_type_base {};
-
-        /**
-         * money sql type
-         */
-        struct sql_money : public sql_data_type_base {
-
-            /**
-             * Construct a new sql money object
-             *
-             * @param [in] v View to bytes to be interpreted as sql_money
-             */
-            inline explicit sql_money(tdsl::byte_view v) noexcept {
-                TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::uint32_t) * 2));
-                // money is represented as an 8-byte signed integer. The TDS value is the money
-                // value multiplied by 10^4. The 8-byte signed integer itself is represented in the
-                // following sequence:
-                // * One 4-byte integer that represents the more significant half.
-                // * One 4-byte integer that represents the less significant half.
-                tdsl::binary_reader<tdsl::endian::little> br{v};
-                const tdsl::uint32_t msh = br.read<tdsl::uint32_t>();
-                const tdsl::uint32_t lsh = br.read<tdsl::uint32_t>();
-                value = static_cast<tdsl::int64_t>((static_cast<tdsl::uint64_t>(msh) << 32) |
-                                                   (static_cast<tdsl::uint64_t>(lsh)));
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Calculate the integer part
-             *
-             * @return tdsl::int64_t sql_money integer part
-             */
-            inline TDSL_NODISCARD tdsl::int64_t integer() const noexcept {
-                return value / 10000;
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Calculate the fraction part
-             *
-             * @return tdsl::int64_t sql_money fraction part
-             */
-            inline TDSL_NODISCARD tdsl::int64_t fraction() const noexcept {
-                return value % 10000;
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Get sql_money value as a double
-             *
-             * @return double sql_money as double
-             */
-            inline operator double() const noexcept {
-                return static_cast<double>(integer()) + (static_cast<double>(fraction()) / 10000);
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Raw 8 byte integer stored in the database
-             */
-            inline TDSL_NODISCARD tdsl::int64_t raw() const noexcept {
-                return value;
-            }
-
-        private:
-            tdsl::int64_t value;
-        };
-
-        /**
-         * smalldatetime sql type
-         */
-        struct sql_smalldatetime : public sql_data_type_base {
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Construct a new SQL smalldatetime object
-             *
-             * @param [in] v View to bytes to be interpreted as sql_smalldatetime
-             */
-            inline explicit sql_smalldatetime(tdsl::byte_view v) noexcept {
-                TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::uint16_t) * 2));
-                tdsl::binary_reader<tdsl::endian::little> br{v};
-                days_elapsed    = br.read<tdsl::uint16_t>();
-                minutes_elapsed = br.read<tdsl::uint16_t>();
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Convert smalldatetime to unix timestamp
-             *
-             * @return tdsl::uint64_t smalldatetime value as unix timestamp
-             */
-            inline tdsl::uint64_t to_unix_timestamp() const noexcept {
-                constexpr auto days_between_epochs = ((1970 - 1900) * 365);
-                if (days_elapsed < days_between_epochs) {
-                    return 0; // 1-1-1970
-                }
-                return ((days_elapsed - days_between_epochs) * 86400) + (minutes_elapsed * 60);
-            }
-
-            // --------------------------------------------------------------------------------
-
-            // One 2-byte unsigned integer that represents the
-            // number of days since January 1, 1900.
-            tdsl::uint16_t days_elapsed;
-            // One 2-byte unsigned integer that represents the
-            // number of minutes elapsed since 12 AM that day.
-            tdsl::uint16_t minutes_elapsed;
-        };
-
-        /**
-         * datetime sql type
-         */
-        struct sql_datetime : public sql_data_type_base {
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Construct a new SQL smalldatetime object
-             *
-             * @param [in] v View to bytes to be interpreted as sql_smalldatetime
-             */
-            inline explicit sql_datetime(tdsl::byte_view v) noexcept {
-                TDSL_ASSERT(v.size_bytes() == (sizeof(tdsl::int32_t) + sizeof(uint32_t)));
-                tdsl::binary_reader<tdsl::endian::little> br{v};
-                days_elapsed         = br.read<tdsl::int32_t>();
-                centiseconds_elapsed = br.read<tdsl::uint32_t>();
-            }
-
-            // --------------------------------------------------------------------------------
-
-            /**
-             * Convert datetime to unix timestamp
-             *
-             * @return tdsl::uint64_t datetime value as unix timestamp
-             */
-            inline tdsl::uint64_t to_unix_timestamp() const noexcept {
-                constexpr auto days_between_epochs = ((1970 - 1900) * 365);
-                if (days_elapsed < days_between_epochs) {
-                    return 0; // 1-1-1970
-                }
-                return ((days_elapsed - days_between_epochs) * 86400ul) +
-                       (centiseconds_elapsed / 100);
-            }
-
-            // --------------------------------------------------------------------------------
-
-            // One 4-byte signed integer that represents the number of days
-            // since January 1, 1900. Negative numbers are allowed to represent
-            // dates since January 1, 1753.
-            tdsl::int32_t days_elapsed;
-            // One 4-byte unsigned integer that represents the number of one
-            // three-hundredths of a second (300 counts per second) elapsed
-            // since 12 AM that day.
-            tdsl::uint32_t centiseconds_elapsed;
-        };
-
-        // struct sql_decimal {
-        //     inline operator tdsl::int64_t() const noexcept {
-        //         return value;
-        //     }
-
-        //     tdsl::int64_t value;
-        // };
-
-        // using sql_numeric = sql_decimal;
-    } // namespace sqltypes
 
     namespace detail {
         template <typename NetImpl>
@@ -217,7 +42,7 @@ namespace tdsl {
          * @return T bytes of data converted to host endianness and reinterpreted as type T
          */
         template <typename T, typename traits::enable_when::arithmetic<T> = true>
-        inline auto as_impl(byte_view data) -> T {
+        inline auto as_impl(byte_view data, const tdsl::tds_column_info &) -> T {
             TDSL_ASSERT_MSG(data.size_bytes() >= sizeof(T),
                             "Given span does not have enough bytes to read a value with type T!");
             return tdsl::binary_reader<tdsl::endian::little>{data}.read<T>();
@@ -227,39 +52,16 @@ namespace tdsl {
 
         template <typename T,
                   typename traits::enable_when::template_instance_of<T, tdsl::span> = true>
-        inline auto as_impl(byte_view data) -> T {
+        inline auto as_impl(byte_view data, const tdsl::tds_column_info &) -> T {
             return data.rebind_cast<typename T::element_type>();
         }
 
         // --------------------------------------------------------------------------------
 
-        template <typename T,
-                  typename traits::enable_when::base_of<sqltypes::sql_data_type_base, T> = true>
-        inline auto as_impl(byte_view data) -> T {
-            return T{data};
+        template <typename T, typename traits::enable_when::base_of<sql_type_base, T> = true>
+        inline auto as_impl(byte_view data, const tdsl::tds_column_info & col) -> T {
+            return T{data, col};
         }
-
-        // --------------------------------------------------------------------------------
-
-        // Decimal is not yet supported.
-        // /**
-        //  * Cast helper for integral types
-        //  *
-        //  * @param [in] data Data to cast
-        //  * @return T bytes of data converted to host endianness and reinterpreted as type T
-        //  */
-        // template <typename T, typename traits::enable_when::same<T, types::sql_decimal> = true>
-        // inline auto as_impl(byte_view data) -> T {
-        //     tdsl::binary_reader<tdsl::endian::little> reader{data};
-        //     const bool sign = reader.read<bool>();
-        //     // read N bytes
-        //     // precision, scale
-        //     // Can be 5, 9, 13, 17
-        //     // TDSL_ASSERT_MSG(data.size_bytes() >= sizeof(T),
-        //     //                 "Given span does not have enough bytes to read a value with type
-        //     //                 T!");
-        //     // return tdsl::binary_reader<tdsl::endian::little>{data}.read<T>();
-        // }
 
     } // namespace detail
 
@@ -267,8 +69,12 @@ namespace tdsl {
      * Non-owning view of a row field.
      */
     struct tdsl_field : public byte_view {
-        using byte_view::span;
+        // using byte_view::span;
         using byte_view::operator=;
+
+        template <typename... Args>
+        inline explicit tdsl_field(const tdsl::tds_column_info & col, Args &&... args) noexcept :
+            byte_view(TDSL_FORWARD(args)...), column(col) {}
 
         // --------------------------------------------------------------------------------
 
@@ -284,7 +90,7 @@ namespace tdsl {
 
         template <typename T>
         inline TDSL_NODISCARD auto as() const noexcept -> T {
-            return detail::as_impl<T>(*this);
+            return detail::as_impl<T>(*this, column_info());
         }
 
         // --------------------------------------------------------------------------------
@@ -302,12 +108,18 @@ namespace tdsl {
             return data() == null_sentinel();
         }
 
+        inline const tdsl::tds_column_info & column_info() const noexcept {
+            return column;
+        }
+
     private:
+        const tdsl::tds_column_info & column;
+
         /**
          * Set this field as NULL.
          */
         void set_null() {
-            (*this) = tdsl_field(null_sentinel(), null_sentinel());
+            (*this) = byte_view(null_sentinel(), null_sentinel());
             TDSL_ASSERT(data() == null_sentinel());
             TDSL_ASSERT(size() == 0);
         }
@@ -320,13 +132,9 @@ namespace tdsl {
          * and a NULL string.
          */
         inline const tdsl::uint8_t * null_sentinel() const noexcept {
-            /**
-             * In order to save some space, we're using
-             * a sentinel value instead of placing a NULL
-             * flag member to tdsl_field.
-             */
-            static tdsl::uint8_t a{};
-            return &a;
+            // We're using the address of column info to indicate
+            // a NULL field.
+            return reinterpret_cast<const tdsl::uint8_t *>(&column);
         }
 
         // --------------------------------------------------------------------------------

--- a/src/tdslite/detail/tdsl_tds_column_info.hpp
+++ b/src/tdslite/detail/tdsl_tds_column_info.hpp
@@ -1,0 +1,61 @@
+/**
+ * ____________________________________________________
+ *
+ * @file   tdsl_tds_column_info.hpp
+ * @author mkg <me@mustafagilor.com>
+ * @date   09.08.2022
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#ifndef TDSL_DETAIL_TDSL_TDS_COLUMN_INFO
+#define TDSL_DETAIL_TDSL_TDS_COLUMN_INFO
+
+#include <tdslite/util/tdsl_inttypes.hpp>
+#include <tdslite/detail/tdsl_data_type.hpp>
+
+namespace tdsl {
+
+    // Packed into 12-byte layout to make
+    // most of the space useful.
+    struct tds_column_info {
+        /* User-defined type value */
+        tdsl::uint16_t user_type              = {0};
+        tdsl::uint16_t flags                  = {0};
+        /* Data type of the column */
+        detail::e_tds_data_type type          = {static_cast<detail::e_tds_data_type>(0)};
+        /* Length of the name of the column */
+        tdsl::uint8_t colname_length_in_chars = {0};
+
+        union {
+            struct {
+                tdsl::uint32_t length;
+            } u32l; // types with variable length of unsigned 32-bit size
+
+            struct {
+                tdsl::uint16_t length;
+                tdsl::uint8_t _unused [2];
+            } u16l; // types with variable length of unsigned 16-bit size
+
+            struct {
+                tdsl::uint8_t length;
+                tdsl::uint8_t _unused [3];
+            } u8l; // types with variable length of unsigned 8-bit size
+
+            struct {
+                tdsl::uint8_t length; // this is the actual length, not the length's length.
+                tdsl::uint8_t _unused [3];
+            } fixed; // types with fixed length
+
+            struct {
+                tdsl::uint8_t length;
+                tdsl::uint8_t precision;
+                tdsl::uint8_t scale;
+                tdsl::uint8_t _unused [1];
+            } ps = {};    // types with precision and scale
+        } typeprops = {}; // type-specific properties
+    };
+} // namespace tdsl
+
+#endif

--- a/src/tdslite/detail/token/tds_colmetadata_token.hpp
+++ b/src/tdslite/detail/token/tds_colmetadata_token.hpp
@@ -18,48 +18,9 @@
 #include <tdslite/util/tdsl_noncopyable.hpp>
 #include <tdslite/detail/tdsl_data_type.hpp>
 #include <tdslite/detail/tdsl_allocator.hpp>
+#include <tdslite/detail/tdsl_tds_column_info.hpp>
 
 namespace tdsl {
-
-    // Packed into 12-byte layout to make
-    // most of the space useful.
-    struct tds_column_info {
-        /* User-defined type value */
-        tdsl::uint16_t user_type              = {0};
-        tdsl::uint16_t flags                  = {0};
-        /* Data type of the column */
-        detail::e_tds_data_type type          = {static_cast<detail::e_tds_data_type>(0)};
-        /* Length of the name of the column */
-        tdsl::uint8_t colname_length_in_chars = {0};
-
-        union {
-            struct {
-                tdsl::uint32_t length;
-            } u32l; // types with variable length of unsigned 32-bit size
-
-            struct {
-                tdsl::uint16_t length;
-                tdsl::uint8_t _unused [2];
-            } u16l; // types with variable length of unsigned 16-bit size
-
-            struct {
-                tdsl::uint8_t length;
-                tdsl::uint8_t _unused [3];
-            } u8l; // types with variable length of unsigned 8-bit size
-
-            struct {
-                tdsl::uint8_t length; // this is the actual length, not the length's length.
-                tdsl::uint8_t _unused [3];
-            } fixed; // types with fixed length
-
-            struct {
-                tdsl::uint8_t length;
-                tdsl::uint8_t precision;
-                tdsl::uint8_t scale;
-                tdsl::uint8_t _unused [1];
-            } ps = {};    // types with precision and scale
-        } typeprops = {}; // type-specific properties
-    };
 
     struct tds_colmetadata_token : public util::noncopyable {
         tdsl::span<tds_column_info> columns         = {};

--- a/src/tdslite/detail/token/tds_loginack_token.hpp
+++ b/src/tdslite/detail/token/tds_loginack_token.hpp
@@ -16,6 +16,7 @@
 #include <tdslite/util/tdsl_span.hpp>
 
 namespace tdsl {
+
     struct tds_login_ack_token {
 
         /**


### PR DESCRIPTION
…types

The new sql_decimal type supports reading numeric and decimal types up to 18 precision. Reading decimal/numeric types greater than >18 precision is not yet supported and will cause a hard failure.

Breaking change: Removed "sqltypes" namespace and renamed all types under it.

- Moved s_bit, s_tinyint, s_smallint, s_int, s_bigint, s_float4, s_float4 to tdslite/detail/sqltypes/sql_basics.hpp and replaced s_ prefix with sql_. The types are no longer under "sqltypes" namespace.
- Moved sql_datetime, sql_smalldatetime, sql_money and sql_type_base  to their own respective files under tdsl/detail/sqltypes
- Introduced a new "sql_decimal" data type for reading numeric/decimal data
- Removed "double" cast function from sql_money as double is aliased to float on AVR and float does not have enough resolution to represent money accurately
- tdsl_command_context::handle_row_token now does not default-construct the fields while allocating them. Each field now will be constructed in-place whilst respective fields' value being read.
- tdsl_field as_impl helper function now has the column info as second parameter
- tdsl_field now holds a reference to its respective column info
- tdsl_field no longer uses a static variable reference as null sentinel. Instead, it now uses its column info address to indicate a null field.
- Moved tds_column_info to its own file from tdsl_colmetadata_token
- Refactored it_tdsl_command_context::exact_numerics_numeric unit test