### PR TITLE
git: added .gitattributes file to exclude some files on export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+* text=auto
+
+# Explicitly declare text files that should be normalized and converted
+# to native line endings on checkout.
+*.json text
+*.md text
+*.env text
+*.txt text
+
+# Declare files that should have LF line endings on checkout.
+*.hpp eol=lf
+*.hxx eol=lf
+*.h eol=lf
+*.cpp eol=lf
+*.c eol=lf
+*.cxx eol=lf
+
+# Export ignore folders
+.hadouken/ export-ignore
+.vscode/ export-ignore
+.cmake/ export-ignore
+.conan/ export-ignore
+.devcontainer/ export-ignore
+.docker/ export-ignore
+.github/ export-ignore
+extras/ export-ignore
+src/tdslite-net/asio/ export-ignore
+tests/ export-ignore
+
+# Export ignore files
+.clang-format export-ignore
+.clang-tidy export-ignore
+.doxyfile export-ignore
+.gdbinit export-ignore
+.gitattributes export-ignore
+.gitconfig export-ignore
+.gitignore export-ignore
+.gitmodules export-ignore
+.lsan-suppressions export-ignore
+CMakeLists.txt export-ignore
+CMakePresets.json export-ignore
+CONTRIBUTING.md export-ignore
+project-metadata.env export-ignore
+workspace.code-workspace export-ignore

--- a/extras/docs/notes.md
+++ b/extras/docs/notes.md
@@ -36,3 +36,6 @@
   - For all boards with ESP MCU's : `pio boards --json-output | jq -c '.[] | select(.mcu|contains("ESP")) | .id' | xargs printf -- '--board\0%s\0' | tr '\n' '\0' | xargs -0 pio ci examples/esp/esp.cpp`
 
   - To find which macro is defined for a specific arduino board: [boards.txt](https://github.com/arduino/ArduinoCore-megaavr/blob/5e639ee40afa693354d3d056ba7fb795a8948c11/boards.txt#L25) (see build.board field of each respective board)
+
+- To generate an library file from the project:
+  - `git archive --format zip --prefix tdslite/ --output tdslite.zip main`


### PR DESCRIPTION
arduino library index seem to use "git archive" in order to get a copy of the repository, which also includes some files we don't want to ship to the end user (e.g. boost.asio based network impl.) added all paths that are not desired in the final archive.