### PR TITLE
tdsl_string_writer: fix wide-char string writing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,23 +17,12 @@
     // Service name defined by docker-compose to be used as remote container 
     "service": "devenv",
     "runServices": [
-        "mssql-2017"
+        "mssql-2022"
     ],
     // Workspace to display in vscode
     "workspaceFolder": "/workspace",
     // Use 'settings' to set *default* container specific settings.json values on container create. 
     // You can edit these settings after create using File > Preferences > Settings > Remote.
-    "settings": {
-        "terminal.integrated.profiles.linux": {
-            "default-zsh": {
-                "path": "/usr/bin/zsh",
-                "args": [
-                    "--login"
-                ]
-            }
-        },
-        "terminal.integrated.defaultProfile.linux": "default-zsh"
-    },
     "containerEnv": {},
     "remoteEnv": {},
     // Run user-specified post creation script (if exist)
@@ -42,63 +31,78 @@
     // Run as user `vscode`
     "remoteUser": "dev",
     // Add the IDs of extensions you want installed when the container is created in the array below.
-    "extensions": [
-        "ms-vscode.cpptools",
-        // Bash Beautify
-        "shakram02.bash-beautify",
-        // C++ Algorithm Mnemonics
-        "davidbroetje.algorithm-mnemonics-vscode",
-        // CMake Language Support
-        "twxs.cmake",
-        // CMake Tools
-        "ms-vscode.cmake-tools",
-        // Python extension
-        "ms-python.python",
-        // GitLens
-        "eamodio.gitlens",
-        // Doxygen Language Support
-        "bbenoist.doxygen",
-        // Doxygen Documentation
-        "cschlosser.doxdocgen",
-        // Gitconfig Syntax
-        "sidneys1.gitconfig",
-        // Markdown All in one
-        "yzhang.markdown-all-in-one",
-        //Markdown PDF
-        "yzane.markdown-pdf",
-        // Markdown Lint
-        "davidanson.vscode-markdownlint",
-        // Shebang Snippets
-        "rpinski.shebang-snippets",
-        // TLDR Pages
-        "bmuskalla.vscode-tldr",
-        // TODO Tree
-        "gruntfuggly.todo-tree",
-        // VS IntelliCode
-        "visualstudioexptteam.vscodeintellicode",
-        // vscode-spotify
-        "shyykoserhiy.vscode-spotify",
-        // Word Count
-        "ms-vscode.wordcount",
-        // vscode-clangd
-        "llvm-vs-code-extensions.vscode-clangd",
-        // Resource monitor
-        "mutantdino.resourcemonitor",
-        // Integrated hex editor
-        "ms-vscode.hexeditor",
-        // Better C++ Syntax
-        "jeff-hykin.better-cpp-syntax",
-        // YAML language support
-        "redhat.vscode-yaml",
-        // Back and forward buttons
-        "grimmer.vscode-back-forward-button",
-        // Crumbs (PCAP viewer)
-        "lukaschneider.crumbs",
-        // MSSQL
-        "ms-mssql.mssql",
-        // Serial monitor
-        "ms-vscode.vscode-serial-monitor",
-        // Arduino
-        "vsciot-vscode.vscode-arduino"
-    ]
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.profiles.linux": {
+                    "default-zsh": {
+                        "path": "/usr/bin/zsh",
+                        "args": [
+                            "--login"
+                        ]
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "default-zsh"
+            },
+            "extensions": [
+                "ms-vscode.cpptools",
+                // Bash Beautify
+                "shakram02.bash-beautify",
+                // C++ Algorithm Mnemonics
+                "davidbroetje.algorithm-mnemonics-vscode",
+                // CMake Language Support
+                "twxs.cmake",
+                // CMake Tools
+                "ms-vscode.cmake-tools",
+                // Python extension
+                "ms-python.python",
+                // GitLens
+                "eamodio.gitlens",
+                // Doxygen Language Support
+                "bbenoist.doxygen",
+                // Doxygen Documentation
+                "cschlosser.doxdocgen",
+                // Gitconfig Syntax
+                "sidneys1.gitconfig",
+                // Markdown All in one
+                "yzhang.markdown-all-in-one",
+                //Markdown PDF
+                "yzane.markdown-pdf",
+                // Markdown Lint
+                "davidanson.vscode-markdownlint",
+                // Shebang Snippets
+                "rpinski.shebang-snippets",
+                // TLDR Pages
+                "bmuskalla.vscode-tldr",
+                // TODO Tree
+                "gruntfuggly.todo-tree",
+                // VS IntelliCode
+                "visualstudioexptteam.vscodeintellicode",
+                // vscode-spotify
+                "shyykoserhiy.vscode-spotify",
+                // Word Count
+                "ms-vscode.wordcount",
+                // vscode-clangd
+                "llvm-vs-code-extensions.vscode-clangd",
+                // Resource monitor
+                "mutantdino.resourcemonitor",
+                // Integrated hex editor
+                "ms-vscode.hexeditor",
+                // Better C++ Syntax
+                "jeff-hykin.better-cpp-syntax",
+                // YAML language support
+                "redhat.vscode-yaml",
+                // Back and forward buttons
+                "grimmer.vscode-back-forward-button",
+                // Crumbs (PCAP viewer)
+                "lukaschneider.crumbs",
+                // MSSQL
+                "ms-mssql.mssql",
+                // Serial monitor
+                "ms-vscode.vscode-serial-monitor",
+                // Arduino
+                "vsciot-vscode.vscode-arduino"
+            ]
+        }
+    }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,8 +10,8 @@
 
 version: '3'
 services:
-  mssql-2017:
-    image: mcr.microsoft.com/mssql/server:2017-latest
+  mssql-2022:
+    image: mcr.microsoft.com/mssql/server:2022-latest
     ports:
       #  host :container
       - "14333:1433"
@@ -20,7 +20,7 @@ services:
       ACCEPT_EULA: "Y"
     networks:
       - tds-devenv-network
-    container_name: tdslite-mssql-2017
+    container_name: tdslite-mssql-2022
   devenv:
     image: ghcr.io/mustafakemalgilor/tdslite/tdslite-devenv:0.3.0
     dns:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,7 +63,7 @@ jobs:
         mssql_version: [2017, 2019, 2022]
     runs-on: ubuntu-latest
     services:
-      mssql-2017:
+      mssql-2022:
         image: mcr.microsoft.com/mssql/server:${{ matrix.mssql_version }}-latest
         env:
           MSSQL_SA_PASSWORD: "2022-tds-lite-test!"
@@ -83,7 +83,7 @@ jobs:
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
           sudo apt-get -y update
           sudo ACCEPT_EULA=y apt-get -y install mssql-tools unixodbc-dev
-          /usr/bin/timeout 90 /bin/bash -c 'until /opt/mssql-tools/bin/sqlcmd -S "mssql-2017" -U "sa" -P "2022-tds-lite-test!" -Q "exit"; do >&2 echo "Database is unavailable - sleeping"; sleep 1; done'
+          /usr/bin/timeout 90 /bin/bash -c 'until /opt/mssql-tools/bin/sqlcmd -S "mssql-2022" -U "sa" -P "2022-tds-lite-test!" -Q "exit"; do >&2 echo "Database is unavailable - sleeping"; sleep 1; done'
       - uses: actions/checkout@v3
         with:
           submodules: "true"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are always welcome. Feel free to file issues/feature requests, sub
 
 ## Preparing the development environment
 
-The project ships a docker-compose file that includes everything needed for developing the `tdslite`, including a built-in `Microsoft SQL Server 2017` for testing. The docker-compose file is primarily in place to work with VSCode's Dev Containers extension. While it's not necessary to use `vscode` for developing `tdslite`, I'd recommend it.
+The project ships a docker-compose file that includes everything needed for developing the `tdslite`, including a built-in `Microsoft SQL Server 2022` for testing. The docker-compose file is primarily in place to work with VSCode's Dev Containers extension. While it's not necessary to use `vscode` for developing `tdslite`, I'd recommend it.
 
 ### Visual Studio Code
 
@@ -42,7 +42,7 @@ It's possible to use the docker-compose file manually to bring the development e
     docker exec -it --user dev:dev tdslite-devenv zsh -c "cd /workspace;zsh -i"
     # stop development environment when not needed
     docker-compose stop
-    # use the "tdslite-mssql-2017" name to get a shell from the database server instead.
+    # use the "tdslite-mssql-2022" name to get a shell from the database server instead.
 ```
 
 #### Building the project (command line)

--- a/examples/minimal-sql-shell/minimal.cpp
+++ b/examples/minimal-sql-shell/minimal.cpp
@@ -184,7 +184,7 @@ int main(void) {
 
     // Define the connection parameters
     decltype(driver)::connection_parameters conn_params;
-    conn_params.server_name         = "mssql-2017";
+    conn_params.server_name         = "mssql-2022";
     conn_params.port                = 1433;
     conn_params.user_name           = "sa";
     conn_params.password            = "2022-tds-lite-test!";

--- a/extras/docs/notes.md
+++ b/extras/docs/notes.md
@@ -1,7 +1,7 @@
 ## Roadmap
 
 - Add support for send buffer fragmentation depending on negotiated packet size [DONE]
-- Add different SQL server versions to integration tests besides MSSQL 2017
+- Add different SQL server versions to integration tests besides MSSQL 2022
 - Add CI pipeline with matrix build (different platforms, toolchains and  versions) [DONE]
 - Add as many board simulators as possible & run tests on them (if possible) [DONE]
 - Write use cases and example applications [IN PROGRESS]

--- a/src/tdslite/detail/tdsl_command_context.hpp
+++ b/src/tdslite/detail/tdsl_command_context.hpp
@@ -132,11 +132,11 @@ namespace tdsl { namespace detail {
          */
         template <typename T, traits::enable_when::same_any_of<T, string_view, wstring_view,
                                                                struct progmem_string_view> = true>
-        inline query_result execute_query(
+        inline auto execute_query(
             T command,
             row_callback_fn_t row_callback = +[](void *, const tds_colmetadata_token &,
                                                  const tdsl_row &) -> void {},
-            void * rcb_uptr                = nullptr) noexcept {
+            void * rcb_uptr                = nullptr) noexcept -> query_result {
             // Reset query state object & reassign row callback
             qstate              = {};
             qstate.row_callback = {row_callback, rcb_uptr};

--- a/src/tdslite/detail/tdsl_driver.hpp
+++ b/src/tdslite/detail/tdsl_driver.hpp
@@ -214,6 +214,30 @@ namespace tdsl { namespace detail {
         // --------------------------------------------------------------------------------
 
         /**
+         * Send a query to the server
+         * (const char16_t array overload)
+         *
+         * @param [in] command SQL command to execute
+         * @param [in] uptr User supplied pointer, will be passed to row_callback as first
+         * argument on every invocation
+         * @param [in] row_callback Callback to invoke for each row received as
+         *             a result to the query. (optional)
+         *
+         * @return tdsl::uint32_t Amount of rows affected from the query
+         */
+        template <tdsl::uint32_t N>
+        inline auto execute_query(
+            const char16_t (&command) [N],
+            sql_command_row_callback row_callback = +[](void *, const tds_colmetadata_token &,
+                                                        const tdsl_row &) -> void {},
+            void * uptr                           = nullptr) noexcept -> sql_command_query_result {
+            TDSL_ASSERT(tds_ctx.is_authenticated());
+            return execute_query(tdsl::wstring_view{command}, row_callback, uptr);
+        }
+
+        // --------------------------------------------------------------------------------
+
+        /**
          * Perform a remote procedure call (e.g. execute a stored procedure or
          * a parameterized query)
          *

--- a/src/tdslite/detail/tdsl_string_writer.hpp
+++ b/src/tdslite/detail/tdsl_string_writer.hpp
@@ -77,7 +77,7 @@ namespace tdsl { namespace detail {
 
         // --------------------------------------------------------------------------------
 
-        static inline void write(typename TDSCTX::rx_mixin & xc, const wstring_view & sv,
+        static inline void write(typename TDSCTX::tx_mixin & xc, const wstring_view & sv,
                                  void (*encoder)(tdsl::uint8_t *,
                                                  tdsl::uint32_t) = nullptr) noexcept {
 

--- a/src/tdslite/util/tdsl_binary_writer.hpp
+++ b/src/tdslite/util/tdsl_binary_writer.hpp
@@ -118,8 +118,9 @@ namespace tdsl {
          * @return false if writer does not have enough space. The underlying
          * span will be unmodified in this case.
          */
-        inline TDSL_NODISCARD auto write(tdsl::byte_view data) noexcept -> bool {
-            TDSL_ASSERT(data);
+
+        template <typename T>
+        inline TDSL_NODISCARD auto write(tdsl::span<T> data) noexcept -> bool {
 
             if (not this->has_bytes(data.size_bytes())) {
                 return false;

--- a/src/tdslite/util/tdsl_string_view.hpp
+++ b/src/tdslite/util/tdsl_string_view.hpp
@@ -46,7 +46,6 @@ namespace tdsl {
         // byte constructor
         inline wstring_view(tdsl::byte_view bv) noexcept : span(bv.rebind_cast<char16_t>()) {
             // If the string is NUL-terminated, omit the NUL terminator.
-
             if (bv.size() > 1 && bv [bv.size() - 2] == '\0' && bv [bv.size() - 1] == '\0') {
                 element_count -= 1;
             }

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -18,6 +18,11 @@ make_component(
             SUFFIX .tdsl_command_context
             SOURCES it_tdsl_command_context.cpp
 
+    TARGET  TYPE UNIT_TEST
+            SUFFIX .tdsl_driver
+            SOURCES it_tdsl_driver.cpp
+            LINK PRIVATE tdslite.net.asio
+
     ALL_NO_AUTO_COMPILATION_UNIT
     ALL_WITH_COVERAGE
     ALL_COVERAGE_TARGETS tdslite

--- a/tests/integration/it_tdsl_driver.cpp
+++ b/tests/integration/it_tdsl_driver.cpp
@@ -1,0 +1,87 @@
+/**
+ * ____________________________________________________
+ * tdsl_driver integration tests
+ *
+ * @file   it_tdsl_driver.cpp
+ * @author mkg <hello@mkg.dev>
+ * @date   04.04.2024
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#include <tdslite/detail/tdsl_driver.hpp>
+#include <tdslite-net/asio/tdsl_netimpl_asio.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using uut_t       = tdsl::detail::tdsl_driver<tdsl::net::tdsl_netimpl_asio>;
+using tds_ctx_t   = uut_t::tds_context_type;
+using login_ctx_t = tdsl::detail::login_context<tdsl::net::tdsl_netimpl_asio>;
+
+/**
+ * Credentials for internal mssql 2022
+ *
+ * @return const login_ctx_t::login_parameters&
+ */
+static inline auto mssql_2022_creds() -> const uut_t::connection_parameters & {
+    static uut_t::connection_parameters params = [] {
+        uut_t::connection_parameters p;
+        p.server_name  = "mssql-2022";
+        p.user_name    = "sa";
+        p.password     = "2022-tds-lite-test!";
+        p.client_name  = "tdslite integration test case";
+        p.app_name     = "tdslite integration test";
+        p.library_name = "tdslite";
+        p.db_name      = "master";
+        return p;
+    }();
+
+    return params;
+}
+
+/**
+ * tds_command_context integration tests.
+ *
+ * NOTE: Prefix all table names with single `#` so
+ * the table becomes a session-specific temporary table.
+ * Otherwise, concurrent tests running in parallel can step
+ * each other's feet.
+ */
+struct tds_driver_it_fixture : public ::testing::Test {
+
+    virtual void SetUp() override {
+        auto r = uut.connect(mssql_2022_creds());
+        ASSERT_EQ(r, uut_t::e_driver_error_code::success);
+    }
+
+public:
+    uut_t uut{};
+};
+
+// --------------------------------------------------------------------------------
+
+TEST_F(tds_driver_it_fixture, execute_query_char16_str) {
+    auto r1 =
+        uut.execute_query(u"CREATE TABLE #test_rpc(x bit, a tinyint, b smallint, c int, d bigint)");
+
+    ASSERT_TRUE(r1);
+    ASSERT_FALSE(r1.status.count_valid());
+    ASSERT_FALSE(r1.status.attn());
+    ASSERT_FALSE(r1.status.error());
+    ASSERT_FALSE(r1.status.in_xact());
+    ASSERT_FALSE(r1.status.more());
+    ASSERT_FALSE(r1.status.srverror());
+    ASSERT_EQ(0, r1.affected_rows);
+    auto r2 = uut.execute_query(u"INSERT INTO #test_rpc VALUES(1, 255, 32767, 2100000000, 42)");
+
+    ASSERT_TRUE(r2);
+    ASSERT_TRUE(r2.status.count_valid());
+    ASSERT_FALSE(r2.status.attn());
+    ASSERT_FALSE(r2.status.error());
+    ASSERT_FALSE(r2.status.in_xact());
+    ASSERT_FALSE(r2.status.more());
+    ASSERT_FALSE(r2.status.srverror());
+    ASSERT_EQ(1, r2.affected_rows);
+}

--- a/tests/integration/it_tdsl_login_context.cpp
+++ b/tests/integration/it_tdsl_login_context.cpp
@@ -33,7 +33,7 @@ using tds_ctx_t = uut_t::tds_context_type;
 struct tds_login_ctx_it_fixture : public ::testing::Test {
 
     virtual void SetUp() override {
-        ASSERT_TRUE(tds_ctx.do_connect("mssql-2017", /*port=*/1433));
+        ASSERT_TRUE(tds_ctx.do_connect("mssql-2022", /*port=*/1433));
     }
 
     virtual void TearDown() override {}
@@ -46,7 +46,7 @@ struct tds_login_ctx_it_fixture : public ::testing::Test {
 
 TEST_F(tds_login_ctx_it_fixture, login) {
     uut_t::login_parameters params;
-    params.server_name  = "mssql-2017";
+    params.server_name  = "mssql-2022";
     params.user_name    = "sa";
     params.password     = "2022-tds-lite-test!";
     params.client_name  = "tdslite integration test case";
@@ -60,7 +60,7 @@ TEST_F(tds_login_ctx_it_fixture, login) {
 
 TEST_F(tds_login_ctx_it_fixture, login_invalid_uname) {
     uut_t::login_parameters params;
-    params.server_name  = "mssql-2017";
+    params.server_name  = "mssql-2022";
     params.user_name    = "as";
     params.password     = "2022-tds-lite-test!";
     params.client_name  = "tdslite integration test case";
@@ -74,7 +74,7 @@ TEST_F(tds_login_ctx_it_fixture, login_invalid_uname) {
 
 TEST_F(tds_login_ctx_it_fixture, login_invalid_pwd) {
     uut_t::login_parameters params;
-    params.server_name  = "mssql-2017";
+    params.server_name  = "mssql-2022";
     params.user_name    = "sa";
     params.password     = "2022-tds-lite-test?";
     params.client_name  = "tdslite integration test case";
@@ -88,7 +88,7 @@ TEST_F(tds_login_ctx_it_fixture, login_invalid_pwd) {
 
 TEST_F(tds_login_ctx_it_fixture, login_invalid_db) {
     uut_t::login_parameters params;
-    params.server_name  = "mssql-2017";
+    params.server_name  = "mssql-2022";
     params.user_name    = "sa";
     params.password     = "2022-tds-lite-test!";
     params.client_name  = "tdslite integration test case";


### PR DESCRIPTION
the writer could not write wide-char strings due to a typo. this patch fixes that, and adds some unit tests to verify.

tdsl_command_context: added char16_t[N] overload to execute_query

tdsl_driver: added unit tests

devcontainer.json: bumped mssql version to 2022
devcontainer.json: updated settings layout